### PR TITLE
Prevent duplicate business-event side effects

### DIFF
--- a/simulator/v03.py
+++ b/simulator/v03.py
@@ -66,6 +66,7 @@ class EnterpriseLab:
         self.events: list[dict] = []
         self.audit: list[dict] = []
         self.completed_idempotency: dict[str, dict] = {}
+        self.processed_event_ids: dict[str, dict] = {}
         self.faults: list[dict] = []
         self._event_seq = 0
         self._audit_seq = 0
@@ -179,6 +180,15 @@ class EnterpriseLab:
 
         return ids
 
+    @staticmethod
+    def _event_fingerprint(event: dict) -> str:
+        return stable_hash({
+            "canonical_id": event["canonical_id"],
+            "operation": event["operation"],
+            "parameters": event["parameters"],
+            "identity_version": event["identity_version"],
+        })
+
     def deliver_due_messages(self) -> list[dict]:
         results = []
         for event in sorted(self.events, key=lambda x: (x["deliver_at"], x["ledger_id"])):
@@ -188,6 +198,32 @@ class EnterpriseLab:
             if event["identity_version"] != self.identity_version:
                 event["status"] = "quarantined"
                 event["reason"] = "identity_version_changed"
+                results.append(copy.deepcopy(event))
+                continue
+
+            fingerprint = self._event_fingerprint(event)
+            previous_event = self.processed_event_ids.get(event["event_id"])
+            if previous_event:
+                event["processed_by"] = previous_event["ledger_id"]
+                if previous_event["fingerprint"] == fingerprint:
+                    event["status"] = "duplicate_ignored"
+                    event["reason"] = "event_id_already_processed"
+                    audit_kind = "duplicate_event_ignored"
+                else:
+                    event["status"] = "quarantined"
+                    event["reason"] = "event_id_payload_collision"
+                    audit_kind = "event_id_collision"
+                self._append_audit(
+                    kind=audit_kind,
+                    correlation_id=event["correlation_id"],
+                    object_id=event["canonical_id"],
+                    detail={
+                        "event_id": event["event_id"],
+                        "ledger_id": event["ledger_id"],
+                        "processed_by": previous_event["ledger_id"],
+                        "reason": event["reason"],
+                    },
+                )
                 results.append(copy.deepcopy(event))
                 continue
 
@@ -202,6 +238,10 @@ class EnterpriseLab:
                 obj["attributes"][field] = event["parameters"].get("value")
                 obj["version"] += 1
                 event["status"] = "delivered"
+                self.processed_event_ids[event["event_id"]] = {
+                    "ledger_id": event["ledger_id"],
+                    "fingerprint": fingerprint,
+                }
             else:
                 event["status"] = "rejected"
                 event["reason"] = "operation_not_supported"

--- a/tests/test_simulator_v03.py
+++ b/tests/test_simulator_v03.py
@@ -113,6 +113,56 @@ class EventLedgerTests(unittest.TestCase):
         self.assertEqual(len(ids), 2)
         self.assertEqual(lab.events[1]["duplicate_of"], lab.events[0]["ledger_id"])
 
+    def test_duplicate_business_event_is_applied_once(self):
+        lab = make_lab()
+        original_version = lab.read_object("bp-200")["version"]
+        lab.inject_fault("duplicate_message", target="EV-DUP-ONCE")
+        ids = lab.emit_message(
+            event_id="EV-DUP-ONCE",
+            canonical_id="bp-200",
+            operation="set_attribute",
+            parameters={"field": "payment_terms", "value": "0002"},
+            correlation_id="corr-dup-once",
+        )
+
+        results = lab.deliver_due_messages()
+
+        self.assertEqual([row["status"] for row in results], ["delivered", "duplicate_ignored"])
+        self.assertEqual(results[1]["reason"], "event_id_already_processed")
+        self.assertEqual(results[1]["processed_by"], ids[0])
+        self.assertEqual(lab.read_object("bp-200")["attributes"]["payment_terms"], "0002")
+        self.assertEqual(lab.read_object("bp-200")["version"], original_version + 1)
+        self.assertEqual(lab.processed_event_ids["EV-DUP-ONCE"]["ledger_id"], ids[0])
+        self.assertIn("duplicate_event_ignored", [row["kind"] for row in lab.export_audit()])
+
+    def test_reused_event_id_with_changed_payload_is_quarantined(self):
+        lab = make_lab()
+        first_ids = lab.emit_message(
+            event_id="EV-COLLISION",
+            canonical_id="bp-200",
+            operation="set_attribute",
+            parameters={"field": "payment_terms", "value": "0002"},
+            correlation_id="corr-first",
+        )
+        first = lab.deliver_due_messages()
+        self.assertEqual(first[0]["status"], "delivered")
+
+        second_ids = lab.emit_message(
+            event_id="EV-COLLISION",
+            canonical_id="bp-200",
+            operation="set_attribute",
+            parameters={"field": "payment_terms", "value": "0003"},
+            correlation_id="corr-second",
+        )
+        second = lab.deliver_due_messages()
+
+        self.assertEqual(second[0]["status"], "quarantined")
+        self.assertEqual(second[0]["reason"], "event_id_payload_collision")
+        self.assertEqual(second[0]["processed_by"], first_ids[0])
+        self.assertEqual(second[0]["ledger_id"], second_ids[0])
+        self.assertEqual(lab.read_object("bp-200")["attributes"]["payment_terms"], "0002")
+        self.assertIn("event_id_collision", [row["kind"] for row in lab.export_audit()])
+
 
 class StateChangeTests(unittest.TestCase):
     def test_race_condition_rejects_second_actor_stale_precondition(self):


### PR DESCRIPTION
Improves the existing synthetic event simulator so repeated delivery of the same business event is deterministic.

- exact duplicates are recorded but applied once;
- reuse of one event ID with different content is quarantined;
- audit records retain both conditions;
- tests prove the business object changes only once and conflicting content does not change the accepted state.

This keeps the simulator aligned with the existing idempotency and evidence contracts used by the SAO reference case.