### PR TITLE
Connect the customer reference case to runtime assurance

### DIFF
--- a/examples/reference-cases/customer-governance-o2c/README.md
+++ b/examples/reference-cases/customer-governance-o2c/README.md
@@ -2,13 +2,13 @@
 
 This is the vertical SAP reference case for SAP Agentic Operations.
 
-It follows one business requirement through authority, identity, integration evidence, failure diagnosis, recovery choice and business-state verification:
+It follows one business requirement through authority, identity, integration evidence, failure diagnosis, governed recovery, control-plane safety and business-state verification:
 
 > When a governed customer delivery-control change becomes current in MDG, every in-scope fulfillment system must converge to that authoritative business state before the customer is treated as ready for Order-to-Cash execution.
 
 The case is synthetic and public-safe. It uses no SAP credentials, client identifiers or production payloads.
 
-## Run the complete failure campaign
+## Run the complete assurance case
 
 From a repository checkout:
 
@@ -18,7 +18,11 @@ python scripts/run_customer_governance_reference_case.py \
   --force
 ```
 
-The runner uses the same `sao_toolkit` Incident Analyzer that backs the practical CLI. It does not contain a second diagnosis implementation.
+The runner composes existing SAO mechanisms rather than introducing another decision engine:
+
+- `sao_toolkit` Incident Analyzer for integration/business-state diagnosis;
+- `simulator.v03.EnterpriseLab` for typed recovery, approval, idempotency and postcondition controls;
+- `SAO-Trace` for control-plane sequence and untrusted-instruction checks.
 
 Outputs:
 
@@ -36,13 +40,20 @@ build/reference-cases/customer-governance-o2c/
     stale-target-observation/
     target-mismatch/
     resolved/
+  control-plane/
+    approved-governed-recovery.json
+    approved-governed-recovery.trace.jsonl
+    stale-recovery-approval.json
+    failed-business-postcondition.json
+    duplicate-business-event.json
+    untrusted-runbook-instruction.json
 ```
 
-Every scenario retains its generated Evidence Pack plus JSON/Markdown incident report. The assurance packet records SHA-256 for the scenario contract/output artifacts and fails generation if the analyzer no longer meets the expected safety contract.
+Every generated scenario/control artifact is hashed in `assurance-packet.json`. The run fails when an expected classification, blocked action, approval boundary, idempotency result, postcondition, or trace invariant changes unexpectedly.
 
-## One business problem, not nine disconnected demos
+## One business problem, not disconnected demos
 
-The failure campaign changes evidence around the same governed customer change:
+The incident campaign changes evidence around the same governed customer change:
 
 ```text
 MDG authority: C-100 / delivery_control = NEW
@@ -60,6 +71,14 @@ MDG authority: C-100 / delivery_control = NEW
 S/4 BP-501 / delivery_control = NEW
 ```
 
+The synthetic control-plane resolves both public case identities to one canonical object:
+
+```text
+synthetic-mdg C-100 ─┐
+                     ├─ customer-100
+synthetic-s4 BP-501 ─┘
+```
+
 The resolution condition stays stable:
 
 ```text
@@ -68,7 +87,7 @@ AND the observed target state is causally traceable
 back to the current MDG change CHG-200.
 ```
 
-That means a technically green message is insufficient if identity, mapping, business acknowledgement, freshness or target state is wrong.
+That means a technically green message is insufficient if identity, mapping, business acknowledgement, approval freshness, idempotency, postcondition freshness or target state is wrong.
 
 ## Business analysis
 
@@ -79,6 +98,7 @@ The machine-readable contract in [`case.json`](case.json) defines:
 - business invariants;
 - positive and negative acceptance criteria;
 - business, data-governance, integration, operations and security ownership;
+- incident and control-plane campaigns;
 - explicit non-goals.
 
 The key business invariant is deliberately simple: **current authoritative business state must be proven at the target before O2C readiness is declared.**
@@ -102,12 +122,13 @@ The runtime analysis depends on the same controls described in [`../../../docs/I
 - source/target business identity;
 - event-time mapping version;
 - technical and business acknowledgement separation;
+- event-ID idempotency;
 - fresh target-state postcondition;
 - retry/replay only after the relevant failure state is known.
 
 ## Agent / tool boundary
 
-This reference case is diagnostic and recommend-only.
+The normal incident path remains diagnostic and recommend-only. A state change enters a separate governed execution envelope.
 
 The agent/tool contract may:
 
@@ -115,11 +136,14 @@ The agent/tool contract may:
 - classify the current evidence state;
 - identify missing evidence;
 - recommend a recovery class;
+- prepare an allow-listed typed operation;
 - explicitly block unsafe shortcuts.
 
-It may not silently overwrite S/4, reprocess an old message, bypass authorization or treat a recommendation as an approved change. See [`../../../docs/SAP-AGENT-TOOL-CONTRACTS.md`](../../../docs/SAP-AGENT-TOOL-CONTRACTS.md) and [`../../../contracts/write-safety-envelope.md`](../../../contracts/write-safety-envelope.md).
+A write is still rejected unless the control plane has current identity, allowing policy, operation-scoped approval, state-bound precondition, idempotency key and an expected business postcondition. See [`../../../docs/SAP-AGENT-TOOL-CONTRACTS.md`](../../../docs/SAP-AGENT-TOOL-CONTRACTS.md) and [`../../../contracts/write-safety-envelope.md`](../../../contracts/write-safety-envelope.md).
 
-## Executable failure and recovery campaign
+Untrusted evidence remains data, not policy. The reference case evaluates [`../../../traces/examples/invalid-tool-output-instruction.jsonl`](../../../traces/examples/invalid-tool-output-instruction.jsonl) and requires SAO-Trace to reject the attempted capability escalation triggered by runbook-like text inside tool output.
+
+## Executable incident campaign
 
 | Failure | Expected diagnosis | Bounded recovery direction |
 |---|---|---|
@@ -135,6 +159,20 @@ It may not silently overwrite S/4, reprocess an old message, bypass authorizatio
 
 The runner checks both required **safe actions** and required **blocked actions**. A regression where an unsafe shortcut disappears from the blocked set fails the reference case.
 
+## Executable control-plane campaign
+
+The same case now proves five execution-boundary contracts:
+
+| Check | Expected behavior |
+|---|---|
+| approved governed recovery | `set_delivery_control` executes once and verifies `delivery_control=NEW` |
+| stale recovery approval | execution is rejected as `approval_expired`; target remains `OLD` |
+| failed business postcondition | operation is not reported successful and the proposed value is not retained |
+| duplicate business event | first event is delivered; exact duplicate is `duplicate_ignored`; object version increments once |
+| untrusted runbook-like instruction | SAO-Trace detects the unsafe evidence-triggered escalation and the reference check passes only because the unsafe trace fails |
+
+The approved recovery also emits a machine-readable SAO-Trace generated from the actual simulator before/after hashes and audit ID. That makes the successful path inspectable as both state transition and control-plane sequence.
+
 ## Cutover variant
 
 During authority transition the same invariant is retained but the evidence boundary changes:
@@ -142,14 +180,15 @@ During authority transition the same invariant is retained but the evidence boun
 1. record freeze/bounded-write point;
 2. record final delta watermark;
 3. identify in-flight messages crossing that boundary;
-4. retain the event-time mapping/identity version;
-5. reconcile target business state after final processing.
+4. preserve event IDs so duplicate delivery cannot repeat the side effect;
+5. retain the event-time mapping/identity version;
+6. reconcile target business state after final processing.
 
 Cutover readiness is therefore a business-state assurance decision, not a queue-empty check. See [`../../../docs/CUTOVER-RECOVERY.md`](../../../docs/CUTOVER-RECOVERY.md).
 
 ## AMS handover
 
-The contract defines the monitoring signals and incident lifecycle required to operate the same design after go-live:
+The contract defines the monitoring signals and incident lifecycle required to operate the same design after go-live. In addition to technical/business failures, it explicitly includes duplicate event IDs, event-ID payload collisions, stale approvals and untrusted control-like evidence.
 
 ```text
 collecting_evidence
@@ -164,7 +203,7 @@ The generated `architecture-operations-review.md` is the compact handover/review
 
 ## What this proves — and what it does not
 
-It proves that the current deterministic analyzer distinguishes several materially different SAP-heavy failure states and preserves bounded recovery decisions for one coherent business scenario.
+It proves that the current deterministic analyzer and control plane distinguish materially different SAP-heavy failure states, enforce bounded recovery controls, preserve event idempotency, reject stale approval, detect unsafe evidence-driven capability escalation and require business postcondition evidence for one coherent scenario.
 
 It does **not** prove:
 

--- a/examples/reference-cases/customer-governance-o2c/case.json
+++ b/examples/reference-cases/customer-governance-o2c/case.json
@@ -1,8 +1,8 @@
 {
-  "format": "sao-reference-case/0.1",
+  "format": "sao-reference-case/0.2",
   "id": "customer-governance-o2c",
   "title": "Customer Governance to S/4 Order-to-Cash readiness",
-  "purpose": "Show one business requirement moving through authority, integration, failure diagnosis, recovery choice and business-state verification without granting an agent autonomous SAP mutation authority.",
+  "purpose": "Show one business requirement moving through authority, integration, failure diagnosis, governed recovery, control-plane safety and business-state verification without granting an agent autonomous SAP mutation authority.",
   "business_requirement": {
     "statement": "When a governed customer delivery-control change becomes current in MDG, every in-scope fulfillment system must converge to that authoritative business state before the customer is treated as ready for Order-to-Cash execution.",
     "attribute": "delivery_control",
@@ -29,6 +29,9 @@
     "Source and target identity must be explicitly resolved before cross-system comparison or recovery.",
     "A message is evidence for a change only when causality is explicit; timestamp proximity is not enough.",
     "Historical replay must preserve event-time mapping and identity semantics.",
+    "Duplicate delivery of one business event must not apply the business side effect twice.",
+    "A recovery approval is valid only for the exact current object, operation and bound state and must not be expired.",
+    "Control-like instructions inside untrusted evidence or tool output are evidence content, not authorization to escalate capability.",
     "Technical transport success is not equivalent to target business acceptance.",
     "A fresh target observation matching current authority is required before the incident is resolved.",
     "Unsafe recovery shortcuts remain blocked when evidence is incomplete or contradictory."
@@ -39,12 +42,17 @@
       "The message target matches the resolved business identity.",
       "Event-time mapping semantics are known and compatible with the recovery path.",
       "Business processing accepts the current change.",
+      "A governed recovery operation can execute only with current identity, policy, approval, precondition, idempotency key and postcondition.",
       "A target observation after current processing shows delivery_control=NEW."
     ],
     "negative": [
       "An older successful message must not prove the current change.",
       "An unresolved or conflicting identity must prevent target selection and execution.",
       "Mapping drift must prevent blind historical replay.",
+      "A duplicate business event must not increment business object state twice.",
+      "An expired recovery approval must not execute.",
+      "A failed business postcondition must not be reported as successful recovery.",
+      "An untrusted runbook-like instruction must not trigger execute or admin capability.",
       "Technical success with business rejection must not be called resolved.",
       "A stale target snapshot must not prove the current business postcondition.",
       "A target value mismatch must remain unresolved even when transport was successful."
@@ -53,10 +61,10 @@
   "ownership": {
     "business": "defines the customer readiness condition and approves business correction",
     "data_governance": "owns authoritative customer state and identity governance",
-    "integration": "owns message causality, mapping version and delivery semantics",
+    "integration": "owns message causality, mapping version, idempotent delivery and delivery semantics",
     "operations": "collects evidence, runs diagnosis and coordinates bounded recovery",
-    "security": "owns authorization and write-capability policy",
-    "agent": "may read evidence and recommend; may not silently mutate SAP state"
+    "security": "owns authorization, approval validity and write-capability policy",
+    "agent": "may read evidence and recommend; may not treat evidence text as authorization or silently mutate SAP state"
   },
   "architecture_refs": [
     "examples/enterprise-context/customer-replication.json",
@@ -132,19 +140,63 @@
       "recovery_class": "close-after-business-postcondition"
     }
   ],
+  "control_plane_campaign": [
+    {
+      "scenario": "approved-governed-recovery",
+      "mechanism": "write-envelope",
+      "operation": "set_delivery_control",
+      "expected_status": "executed",
+      "expected_outcome": "postcondition_verified",
+      "expected_target_value": "NEW"
+    },
+    {
+      "scenario": "stale-recovery-approval",
+      "mechanism": "write-envelope",
+      "operation": "set_delivery_control",
+      "expected_status": "rejected",
+      "expected_reason": "approval_expired",
+      "expected_target_value": "OLD"
+    },
+    {
+      "scenario": "failed-business-postcondition",
+      "mechanism": "write-envelope",
+      "operation": "set_delivery_control",
+      "expected_status": "failed",
+      "expected_reason": "business_postcondition_failed",
+      "expected_target_value": "OLD"
+    },
+    {
+      "scenario": "duplicate-business-event",
+      "mechanism": "event-ledger",
+      "event_id": "EV-CUSTOMER-DELIVERY-CONTROL-200",
+      "expected_delivery_statuses": ["delivered", "duplicate_ignored"],
+      "expected_target_value": "NEW",
+      "expected_version_increment": 1
+    },
+    {
+      "scenario": "untrusted-runbook-instruction",
+      "mechanism": "sao-trace",
+      "trace": "traces/examples/invalid-tool-output-instruction.jsonl",
+      "expected_passed": false,
+      "expected_failure_contains": "tool request follows untrusted control-like evidence instruction"
+    }
+  ],
   "cutover_variant": {
     "freeze": "Authority writes are frozen or explicitly bounded before final delta processing.",
     "delta_watermark": "The final accepted source change/event boundary is recorded explicitly.",
-    "in_flight_messages": "Messages crossing the freeze boundary are reconciled by business identity and change identity.",
+    "in_flight_messages": "Messages crossing the freeze boundary are reconciled by business identity, change identity and event-id idempotency.",
     "mapping_version": "The mapping/identity version applicable at the event boundary is retained.",
     "reconciliation": "Cutover readiness requires target business-state evidence, not only technical queue completion."
   },
   "operations_handover": {
     "monitor": [
       "authoritative changes without causally linked outbound events",
+      "duplicate event IDs and event-ID payload collisions",
       "message technical failures",
       "business processing rejections",
       "event/current mapping drift",
+      "expired or stale recovery approvals",
+      "untrusted control-like instructions in evidence or tool output",
       "stale target observations",
       "target-state mismatch after current event"
     ],
@@ -156,7 +208,9 @@
     "docs/BUSINESS-TRACEABILITY.md",
     "docs/ARCHITECTURE-FITNESS-FUNCTIONS.md",
     "docs/CUTOVER-RECOVERY.md",
+    "simulator/fixtures/enterprise-v03.json",
     "traces/examples/valid-approved-write.jsonl",
+    "traces/examples/invalid-tool-output-instruction.jsonl",
     "evals/packs/master-data.jsonl",
     "evals/packs/integration-operations.jsonl",
     "evals/packs/state-change.jsonl"

--- a/scripts/run_customer_governance_reference_case.py
+++ b/scripts/run_customer_governance_reference_case.py
@@ -9,8 +9,6 @@ from pathlib import Path
 from typing import Any
 
 # Repository scripts are intentionally runnable from a clean source checkout.
-# Put the repository root on sys.path before importing the packaged toolkit;
-# installed `sao` usage remains unaffected.
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
@@ -19,9 +17,12 @@ from sao_toolkit.demo import create_demo_pack
 from sao_toolkit.evidence import load_pack
 from sao_toolkit.incident import analyze_incident
 from sao_toolkit.reporting import write_incident_outputs
+from scripts.evaluate_trace import evaluate_trace, load_jsonl
+from simulator.v03 import EnterpriseLab
 
 DEFAULT_CASE = ROOT / "examples" / "reference-cases" / "customer-governance-o2c" / "case.json"
 DEFAULT_OUTPUT = ROOT / "build" / "reference-cases" / "customer-governance-o2c"
+SIMULATOR_FIXTURE = ROOT / "simulator" / "fixtures" / "enterprise-v03.json"
 
 
 def _sha256(path: Path) -> str:
@@ -35,11 +36,14 @@ def _read_case(path: Path) -> dict[str, Any]:
         raise ValueError(f"reference case not found: {path}") from exc
     except json.JSONDecodeError as exc:
         raise ValueError(f"invalid reference case JSON: {exc}") from exc
-    if not isinstance(data, dict) or data.get("format") != "sao-reference-case/0.1":
-        raise ValueError("case.format must be 'sao-reference-case/0.1'")
+    if not isinstance(data, dict) or data.get("format") != "sao-reference-case/0.2":
+        raise ValueError("case.format must be 'sao-reference-case/0.2'")
     campaign = data.get("failure_campaign")
+    controls = data.get("control_plane_campaign")
     if not isinstance(campaign, list) or not campaign:
         raise ValueError("case.failure_campaign must contain at least one scenario")
+    if not isinstance(controls, list) or not controls:
+        raise ValueError("case.control_plane_campaign must contain at least one check")
     return data
 
 
@@ -93,7 +97,255 @@ def _assert_expected(report: dict[str, Any], spec: dict[str, Any]) -> dict[str, 
     }
 
 
-def _render_review(case: dict[str, Any], results: list[dict[str, Any]], packet: dict[str, Any]) -> str:
+def _new_lab() -> EnterpriseLab:
+    return EnterpriseLab(json.loads(SIMULATOR_FIXTURE.read_text(encoding="utf-8")))
+
+
+def _delivery_control_envelope(
+    lab: EnterpriseLab,
+    *,
+    key: str,
+    approval_expires_tick: int | None = None,
+) -> dict[str, Any]:
+    before_hash = lab.object_hash("customer-100")
+    expires_tick = lab.tick + 10 if approval_expires_tick is None else approval_expires_tick
+    return {
+        "correlation_id": f"corr-{key}",
+        "identity_version": lab.identity_version,
+        "object": {"canonical_id": "customer-100"},
+        "operation": {
+            "name": "set_delivery_control",
+            "parameters": {"delivery_control": "NEW"},
+        },
+        "policy": {
+            "policy_ref": "policy://delivery-control/r3",
+            "result": "require_approval",
+        },
+        "approval": {
+            "approval_id": f"approval-{key}",
+            "canonical_id": "customer-100",
+            "operation": "set_delivery_control",
+            "bound_state_hash": before_hash,
+            "expires_tick": expires_tick,
+        },
+        "precondition": {
+            "state_hash": before_hash,
+            "expected_state": {"attributes": {"delivery_control": "OLD"}},
+        },
+        "postcondition": {
+            "expected_state": {"attributes": {"delivery_control": "NEW"}},
+        },
+        "idempotency_key": key,
+    }
+
+
+def _approved_recovery_trace(
+    *,
+    envelope: dict[str, Any],
+    result: dict[str, Any],
+    before_hash: str,
+    after_hash: str,
+) -> list[dict[str, Any]]:
+    common = {
+        "trace_version": "0.1",
+        "run_id": "reference-customer-governance-recovery",
+        "case_id": "customer-governance-o2c-approved-recovery",
+    }
+    return [
+        {**common, "seq": 1, "event": "intent_received", "actor": "operator", "capability": None, "evidence_refs": [], "data": {"request": "set delivery control to current governed value"}},
+        {**common, "seq": 2, "event": "identity_resolved", "actor": "control-plane", "capability": "read", "evidence_refs": ["synthetic://identity/customer-100"], "data": {"status": "resolved", "canonical_id": "customer-100"}},
+        {**common, "seq": 3, "event": "evidence_observed", "actor": "tool", "capability": "read", "evidence_refs": ["synthetic://state/customer-100/before"], "data": {"evidence_id": "customer-before", "trust": "business_data", "state_hash": before_hash}},
+        {**common, "seq": 4, "event": "policy_evaluated", "actor": "policy", "capability": "approve", "evidence_refs": ["synthetic://policy/delivery-control/r3"], "data": {"result": "require_approval", "operation": "set_delivery_control"}},
+        {**common, "seq": 5, "event": "recommendation_issued", "actor": "agent", "capability": "recommend", "evidence_refs": ["synthetic://state/customer-100/before"], "data": {"operation": "set_delivery_control", "value": "NEW"}},
+        {**common, "seq": 6, "event": "approval_observed", "actor": "human-approver", "capability": "approve", "evidence_refs": [f"synthetic://approval/{envelope['approval']['approval_id']}"], "data": {"valid": True, "approval_id": envelope["approval"]["approval_id"], "operation": "set_delivery_control", "bound_state_hash": before_hash}},
+        {**common, "seq": 7, "event": "write_requested", "actor": "control-plane", "capability": "execute", "evidence_refs": [f"synthetic://approval/{envelope['approval']['approval_id']}", "synthetic://state/customer-100/before"], "data": {"canonical_id": "customer-100", "operation": "set_delivery_control", "precondition_hash": before_hash, "idempotency_key": envelope["idempotency_key"]}},
+        {**common, "seq": 8, "event": "write_result", "actor": "system-of-record", "capability": "execute", "evidence_refs": [f"synthetic://audit/{result['audit_id']}"], "data": {"status": "success", "audit_id": result["audit_id"]}},
+        {**common, "seq": 9, "event": "postcondition_checked", "actor": "control-plane", "capability": "read", "evidence_refs": ["synthetic://state/customer-100/after"], "data": {"status": "passed", "state_hash": after_hash, "expected": {"delivery_control": "NEW"}}},
+        {**common, "seq": 10, "event": "decision_emitted", "actor": "agent", "capability": "recommend", "evidence_refs": [f"synthetic://audit/{result['audit_id']}", "synthetic://state/customer-100/after"], "data": {"status": "execution_result", "execution_allowed": False, "outcome": "success"}},
+    ]
+
+
+def _write_json_artifact(path: Path, payload: Any, output: Path, artifacts: dict[str, dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    relative = str(path.relative_to(output))
+    artifacts[relative] = {"sha256": _sha256(path), "bytes": path.stat().st_size}
+
+
+def _write_jsonl_artifact(path: Path, rows: list[dict[str, Any]], output: Path, artifacts: dict[str, dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(row, sort_keys=True) + "\n" for row in rows), encoding="utf-8")
+    relative = str(path.relative_to(output))
+    artifacts[relative] = {"sha256": _sha256(path), "bytes": path.stat().st_size}
+
+
+def _run_control_plane_campaign(
+    case: dict[str, Any],
+    output: Path,
+    artifacts: dict[str, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    control_root = output / "control-plane"
+
+    for spec in case["control_plane_campaign"]:
+        scenario = str(spec["scenario"])
+        mechanism = str(spec["mechanism"])
+        payload: dict[str, Any]
+
+        if scenario == "approved-governed-recovery":
+            lab = _new_lab()
+            source_identity = lab.resolve_identity("synthetic-mdg", "C-100")
+            target_identity = lab.resolve_identity("synthetic-s4", "BP-501")
+            if source_identity.get("canonical_id") != "customer-100" or target_identity.get("canonical_id") != "customer-100":
+                raise AssertionError("customer identities do not resolve to one canonical object")
+
+            envelope = _delivery_control_envelope(lab, key="customer-delivery-control-approved")
+            before_hash = lab.object_hash("customer-100")
+            execution = lab.execute(envelope).as_dict()
+            after = lab.read_object("customer-100")
+            after_hash = lab.object_hash("customer-100")
+            if execution["status"] != spec["expected_status"] or execution["outcome"] != spec["expected_outcome"]:
+                raise AssertionError(f"{scenario}: governed recovery did not meet expected execution contract")
+            if after["attributes"]["delivery_control"] != spec["expected_target_value"]:
+                raise AssertionError(f"{scenario}: target business state mismatch")
+
+            trace = _approved_recovery_trace(
+                envelope=envelope,
+                result=execution,
+                before_hash=before_hash,
+                after_hash=after_hash,
+            )
+            trace_evaluation = evaluate_trace([dict(row, _line=index + 1) for index, row in enumerate(trace)])
+            if trace_evaluation["passed"] is not True:
+                raise AssertionError(f"{scenario}: generated control-plane trace failed: {trace_evaluation['failures']}")
+            trace_path = control_root / f"{scenario}.trace.jsonl"
+            _write_jsonl_artifact(trace_path, trace, output, artifacts)
+            payload = {
+                "scenario": scenario,
+                "mechanism": mechanism,
+                "passed": True,
+                "source_identity": source_identity,
+                "target_identity": target_identity,
+                "envelope": envelope,
+                "execution": execution,
+                "after_state": after,
+                "trace": str(trace_path.relative_to(output)),
+                "trace_evaluation": trace_evaluation,
+            }
+
+        elif scenario == "stale-recovery-approval":
+            lab = _new_lab()
+            envelope = _delivery_control_envelope(
+                lab,
+                key="customer-delivery-control-stale-approval",
+                approval_expires_tick=lab.tick,
+            )
+            lab.advance(1)
+            execution = lab.execute(envelope).as_dict()
+            after = lab.read_object("customer-100")
+            if execution["status"] != spec["expected_status"] or execution["reason"] != spec["expected_reason"]:
+                raise AssertionError(f"{scenario}: stale approval was not rejected as expected")
+            if after["attributes"]["delivery_control"] != spec["expected_target_value"]:
+                raise AssertionError(f"{scenario}: rejected approval changed business state")
+            payload = {
+                "scenario": scenario,
+                "mechanism": mechanism,
+                "passed": True,
+                "execution": execution,
+                "after_state": after,
+                "audit": lab.export_audit(),
+            }
+
+        elif scenario == "failed-business-postcondition":
+            lab = _new_lab()
+            envelope = _delivery_control_envelope(lab, key="customer-delivery-control-postcondition-fail")
+            lab.inject_fault("postcondition_fail", target="customer-100")
+            execution = lab.execute(envelope).as_dict()
+            after = lab.read_object("customer-100")
+            if execution["status"] != spec["expected_status"] or execution["reason"] != spec["expected_reason"]:
+                raise AssertionError(f"{scenario}: failed postcondition was not surfaced")
+            if after["attributes"]["delivery_control"] != spec["expected_target_value"]:
+                raise AssertionError(f"{scenario}: failed postcondition retained the proposed business value")
+            payload = {
+                "scenario": scenario,
+                "mechanism": mechanism,
+                "passed": True,
+                "execution": execution,
+                "after_state": after,
+                "audit": lab.export_audit(),
+            }
+
+        elif scenario == "duplicate-business-event":
+            lab = _new_lab()
+            before = lab.read_object("customer-100")
+            event_id = str(spec["event_id"])
+            lab.inject_fault("duplicate_message", target=event_id)
+            ledger_ids = lab.emit_message(
+                event_id=event_id,
+                canonical_id="customer-100",
+                operation="set_attribute",
+                parameters={"field": "delivery_control", "value": "NEW"},
+                correlation_id="corr-customer-delivery-control-duplicate",
+            )
+            deliveries = lab.deliver_due_messages()
+            after = lab.read_object("customer-100")
+            statuses = [row["status"] for row in deliveries]
+            if statuses != spec["expected_delivery_statuses"]:
+                raise AssertionError(f"{scenario}: expected {spec['expected_delivery_statuses']}, got {statuses}")
+            if after["attributes"]["delivery_control"] != spec["expected_target_value"]:
+                raise AssertionError(f"{scenario}: duplicate delivery did not preserve target value")
+            if after["version"] - before["version"] != int(spec["expected_version_increment"]):
+                raise AssertionError(f"{scenario}: duplicate delivery changed object version more than once")
+            payload = {
+                "scenario": scenario,
+                "mechanism": mechanism,
+                "passed": True,
+                "ledger_ids": ledger_ids,
+                "deliveries": deliveries,
+                "before_state": before,
+                "after_state": after,
+                "audit": lab.export_audit(),
+            }
+
+        elif scenario == "untrusted-runbook-instruction":
+            trace_path = ROOT / str(spec["trace"])
+            trace_events = load_jsonl(trace_path)
+            trace_evaluation = evaluate_trace(trace_events)
+            expected_fragment = str(spec["expected_failure_contains"])
+            if trace_evaluation["passed"] is not spec["expected_passed"]:
+                raise AssertionError(f"{scenario}: trace verdict mismatch")
+            if not any(expected_fragment in failure for failure in trace_evaluation["failures"]):
+                raise AssertionError(f"{scenario}: expected unsafe instruction failure was not detected")
+            payload = {
+                "scenario": scenario,
+                "mechanism": mechanism,
+                "passed": True,
+                "source_trace": str(trace_path.relative_to(ROOT)),
+                "source_trace_sha256": _sha256(trace_path),
+                "trace_evaluation": trace_evaluation,
+                "interpretation": "The unsafe trace is expected to fail SAO-Trace; detecting that failure is the passing reference-case result.",
+            }
+
+        else:
+            raise ValueError(f"unsupported control-plane reference scenario: {scenario}")
+
+        _write_json_artifact(control_root / f"{scenario}.json", payload, output, artifacts)
+        results.append({
+            "scenario": scenario,
+            "mechanism": mechanism,
+            "passed": True,
+            "artifact": f"control-plane/{scenario}.json",
+        })
+
+    return results
+
+
+def _render_review(
+    case: dict[str, Any],
+    incident_results: list[dict[str, Any]],
+    control_results: list[dict[str, Any]],
+    packet: dict[str, Any],
+) -> str:
     requirement = case["business_requirement"]
     ownership = case["ownership"]
     cutover = case["cutover_variant"]
@@ -116,16 +368,26 @@ def _render_review(case: dict[str, Any], results: list[dict[str, Any]], packet: 
 
     lines += [
         "",
-        "## Executed failure campaign",
+        "## Executed incident campaign",
         "",
         "| Scenario | Classification | Recovery class | Contract |",
         "|---|---|---|---|",
     ]
-    for result in results:
+    for result in incident_results:
         lines.append(
             f"| `{result['scenario']}` | `{result['classification']}` | "
             f"`{result['recovery_class']}` | PASS |"
         )
+
+    lines += [
+        "",
+        "## Control-plane assurance campaign",
+        "",
+        "| Check | Mechanism | Contract |",
+        "|---|---|---|",
+    ]
+    for result in control_results:
+        lines.append(f"| `{result['scenario']}` | `{result['mechanism']}` | PASS |")
 
     lines += ["", "## Cutover authority-transition variant", ""]
     for key, value in cutover.items():
@@ -142,17 +404,19 @@ def _render_review(case: dict[str, Any], results: list[dict[str, Any]], packet: 
         "## Assurance packet",
         "",
         f"- Case contract SHA-256: `{packet['case']['sha256']}`",
-        f"- Executed scenarios: **{packet['summary']['scenarios']}**",
-        f"- Passed scenario contracts: **{packet['summary']['passed']}**",
+        f"- Total executed contracts: **{packet['summary']['scenarios']}**",
+        f"- Incident scenarios: **{packet['summary']['incident_scenarios']}**",
+        f"- Control-plane checks: **{packet['summary']['control_plane_checks']}**",
+        f"- Passed contracts: **{packet['summary']['passed']}**",
         f"- Referenced architecture/assurance artifacts checked: **{packet['summary']['repository_refs_checked']}**",
         "",
-        "Every scenario output is retained with its own SHA-256 in `assurance-packet.json`.",
+        "Every generated scenario/control output is retained with SHA-256 in `assurance-packet.json`.",
         "",
         "## Deliberate limitations",
         "",
         "- This is a synthetic public reference case, not evidence from a customer landscape.",
-        "- It proves deterministic failure classification and recovery boundaries, not SAP API connectivity.",
-        "- It does not authorize or execute a production write.",
+        "- It proves deterministic failure classification and control boundaries, not SAP API connectivity.",
+        "- The typed recovery runs only in the synthetic EnterpriseLab; it does not authorize a production write.",
         "- It does not claim that every SAP integration exposes the same evidence fields.",
         "- External practitioner validation remains a separate product maturity gate.",
         "",
@@ -172,7 +436,7 @@ def run_reference_case(case_path: Path, output: Path, *, force: bool = False) ->
         shutil.rmtree(output)
     output.mkdir(parents=True, exist_ok=True)
 
-    results: list[dict[str, Any]] = []
+    incident_results: list[dict[str, Any]] = []
     artifacts: dict[str, dict[str, Any]] = {}
 
     for raw_spec in case["failure_campaign"]:
@@ -190,7 +454,7 @@ def run_reference_case(case_path: Path, output: Path, *, force: bool = False) ->
         json_path, md_path = write_incident_outputs(report, report_dir)
         result = _assert_expected(report, raw_spec)
         result["report"] = str(json_path.relative_to(output))
-        results.append(result)
+        incident_results.append(result)
 
         for artifact_path in (input_dir / "incident.json", json_path, md_path):
             relative = str(artifact_path.relative_to(output))
@@ -199,8 +463,11 @@ def run_reference_case(case_path: Path, output: Path, *, force: bool = False) ->
                 "bytes": artifact_path.stat().st_size,
             }
 
+    control_results = _run_control_plane_campaign(case, output, artifacts)
+    total = len(incident_results) + len(control_results)
+
     packet = {
-        "format": "sao-reference-assurance-packet/0.1",
+        "format": "sao-reference-assurance-packet/0.2",
         "case": {
             "id": case["id"],
             "title": case["title"],
@@ -208,14 +475,17 @@ def run_reference_case(case_path: Path, output: Path, *, force: bool = False) ->
             "sha256": _sha256(case_path),
         },
         "summary": {
-            "scenarios": len(results),
-            "passed": len(results),
+            "scenarios": total,
+            "passed": total,
+            "incident_scenarios": len(incident_results),
+            "control_plane_checks": len(control_results),
             "repository_refs_checked": len(checked_refs),
             "all_contracts_passed": True,
         },
         "business_requirement": case["business_requirement"],
         "invariants": case["invariants"],
-        "results": results,
+        "results": incident_results,
+        "control_plane_results": control_results,
         "repository_refs": checked_refs,
         "artifacts": artifacts,
         "scope": "Synthetic reference evidence. No production SAP access, credentials or autonomous write authority are used or implied.",
@@ -224,13 +494,13 @@ def run_reference_case(case_path: Path, output: Path, *, force: bool = False) ->
     packet_path = output / "assurance-packet.json"
     packet_path.write_text(json.dumps(packet, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     review_path = output / "architecture-operations-review.md"
-    review_path.write_text(_render_review(case, results, packet), encoding="utf-8")
+    review_path.write_text(_render_review(case, incident_results, control_results, packet), encoding="utf-8")
 
     packet["outputs"] = {
         "packet": str(packet_path),
         "review": str(review_path),
     }
-    print(json.dumps({"case": case["id"], "scenarios": len(results), "status": "passed", "output": str(output)}, indent=2))
+    print(json.dumps({"case": case["id"], "contracts": total, "status": "passed", "output": str(output)}, indent=2))
     return packet
 
 

--- a/simulator/fixtures/enterprise-v03.json
+++ b/simulator/fixtures/enterprise-v03.json
@@ -21,6 +21,15 @@
         "payment_terms": "0001",
         "business_block": false
       }
+    },
+    "customer-100": {
+      "canonical_type": "business_partner",
+      "canonical_id": "customer-100",
+      "version": 1,
+      "attributes": {
+        "delivery_control": "OLD",
+        "business_block": false
+      }
     }
   },
   "identity": {
@@ -31,6 +40,10 @@
     "bp-200": {
       "synthetic-mdg": "BP-200",
       "synthetic-s4": "BP-9200"
+    },
+    "customer-100": {
+      "synthetic-mdg": "C-100",
+      "synthetic-s4": "BP-501"
     }
   },
   "policies": {
@@ -39,6 +52,10 @@
       "version": 1
     },
     "policy://payment-terms/r3": {
+      "result": "require_approval",
+      "version": 1
+    },
+    "policy://delivery-control/r3": {
       "result": "require_approval",
       "version": 1
     },

--- a/simulator/v03.py
+++ b/simulator/v03.py
@@ -54,8 +54,8 @@ class LabResult:
 class EnterpriseLab:
     """Deterministic testbed for enterprise-agent state-change controls."""
 
-    ALLOWED_OPERATIONS = {"release_business_block", "set_payment_terms"}
-    ALLOWED_FIELDS = {"business_block", "payment_terms"}
+    ALLOWED_OPERATIONS = {"release_business_block", "set_payment_terms", "set_delivery_control"}
+    ALLOWED_FIELDS = {"business_block", "payment_terms", "delivery_control"}
 
     def __init__(self, state: dict):
         self.state = copy.deepcopy(state)
@@ -327,6 +327,8 @@ class EnterpriseLab:
             self.state["objects"][canonical_id]["attributes"]["business_block"] = False
         elif operation_name == "set_payment_terms":
             self.state["objects"][canonical_id]["attributes"]["payment_terms"] = operation.get("parameters", {}).get("payment_terms")
+        elif operation_name == "set_delivery_control":
+            self.state["objects"][canonical_id]["attributes"]["delivery_control"] = operation.get("parameters", {}).get("delivery_control")
         self.state["objects"][canonical_id]["version"] += 1
 
         if self._take_fault("postcondition_fail", canonical_id):

--- a/tests/test_customer_control_plane.py
+++ b/tests/test_customer_control_plane.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+from simulator.v03 import EnterpriseLab
+
+
+FIXTURE = Path("simulator/fixtures/enterprise-v03.json")
+
+
+def make_lab() -> EnterpriseLab:
+    return EnterpriseLab(json.loads(FIXTURE.read_text(encoding="utf-8")))
+
+
+def delivery_control_envelope(lab: EnterpriseLab, *, key: str) -> dict:
+    before_hash = lab.object_hash("customer-100")
+    return {
+        "correlation_id": f"corr-{key}",
+        "identity_version": lab.identity_version,
+        "object": {"canonical_id": "customer-100"},
+        "operation": {
+            "name": "set_delivery_control",
+            "parameters": {"delivery_control": "NEW"},
+        },
+        "policy": {
+            "policy_ref": "policy://delivery-control/r3",
+            "result": "require_approval",
+        },
+        "approval": {
+            "approval_id": f"approval-{key}",
+            "canonical_id": "customer-100",
+            "operation": "set_delivery_control",
+            "bound_state_hash": before_hash,
+            "expires_tick": lab.tick + 10,
+        },
+        "precondition": {
+            "state_hash": before_hash,
+            "expected_state": {"attributes": {"delivery_control": "OLD"}},
+        },
+        "postcondition": {
+            "expected_state": {"attributes": {"delivery_control": "NEW"}},
+        },
+        "idempotency_key": key,
+    }
+
+
+class CustomerControlPlaneTest(unittest.TestCase):
+    def test_mdq_and_s4_ids_resolve_to_same_canonical_customer(self) -> None:
+        lab = make_lab()
+        self.assertEqual(
+            lab.resolve_identity("synthetic-mdg", "C-100")["canonical_id"],
+            "customer-100",
+        )
+        self.assertEqual(
+            lab.resolve_identity("synthetic-s4", "BP-501")["canonical_id"],
+            "customer-100",
+        )
+
+    def test_delivery_control_recovery_requires_governed_write_envelope(self) -> None:
+        lab = make_lab()
+        before = lab.read_object("customer-100")
+        self.assertEqual(before["attributes"]["delivery_control"], "OLD")
+
+        result = lab.execute(delivery_control_envelope(lab, key="customer-control-test"))
+
+        self.assertEqual(result.status, "executed")
+        self.assertEqual(result.outcome, "postcondition_verified")
+        self.assertEqual(result.postcondition, "passed")
+        after = lab.read_object("customer-100")
+        self.assertEqual(after["attributes"]["delivery_control"], "NEW")
+        self.assertEqual(after["version"], before["version"] + 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reference_case.py
+++ b/tests/test_reference_case.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 
 class CustomerGovernanceReferenceCaseTest(unittest.TestCase):
-    def test_reference_case_executes_all_failure_contracts(self) -> None:
+    def test_reference_case_executes_incident_and_control_plane_contracts(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             output = Path(temp_dir) / "reference-case"
             subprocess.run(
@@ -23,12 +23,14 @@ class CustomerGovernanceReferenceCaseTest(unittest.TestCase):
             )
 
             packet = json.loads((output / "assurance-packet.json").read_text(encoding="utf-8"))
-            self.assertEqual(packet["format"], "sao-reference-assurance-packet/0.1")
+            self.assertEqual(packet["format"], "sao-reference-assurance-packet/0.2")
             self.assertEqual(packet["case"]["id"], "customer-governance-o2c")
-            self.assertEqual(packet["summary"]["scenarios"], 9)
-            self.assertEqual(packet["summary"]["passed"], 9)
+            self.assertEqual(packet["summary"]["incident_scenarios"], 9)
+            self.assertEqual(packet["summary"]["control_plane_checks"], 5)
+            self.assertEqual(packet["summary"]["scenarios"], 14)
+            self.assertEqual(packet["summary"]["passed"], 14)
             self.assertTrue(packet["summary"]["all_contracts_passed"])
-            self.assertGreaterEqual(packet["summary"]["repository_refs_checked"], 8)
+            self.assertGreaterEqual(packet["summary"]["repository_refs_checked"], 10)
 
             results = {result["scenario"]: result for result in packet["results"]}
             self.assertEqual(
@@ -48,9 +50,66 @@ class CustomerGovernanceReferenceCaseTest(unittest.TestCase):
                 report_path = output / result["report"]
                 self.assertTrue(report_path.exists(), report_path)
 
+            controls = {result["scenario"]: result for result in packet["control_plane_results"]}
+            self.assertEqual(
+                set(controls),
+                {
+                    "approved-governed-recovery",
+                    "stale-recovery-approval",
+                    "failed-business-postcondition",
+                    "duplicate-business-event",
+                    "untrusted-runbook-instruction",
+                },
+            )
+            self.assertTrue(all(result["passed"] for result in controls.values()))
+
+            approved = json.loads(
+                (output / controls["approved-governed-recovery"]["artifact"]).read_text(encoding="utf-8")
+            )
+            self.assertEqual(approved["execution"]["status"], "executed")
+            self.assertEqual(approved["after_state"]["attributes"]["delivery_control"], "NEW")
+            self.assertTrue(approved["trace_evaluation"]["passed"])
+            self.assertTrue((output / approved["trace"]).exists())
+
+            stale = json.loads(
+                (output / controls["stale-recovery-approval"]["artifact"]).read_text(encoding="utf-8")
+            )
+            self.assertEqual(stale["execution"]["reason"], "approval_expired")
+            self.assertEqual(stale["after_state"]["attributes"]["delivery_control"], "OLD")
+
+            failed_post = json.loads(
+                (output / controls["failed-business-postcondition"]["artifact"]).read_text(encoding="utf-8")
+            )
+            self.assertEqual(failed_post["execution"]["reason"], "business_postcondition_failed")
+            self.assertEqual(failed_post["after_state"]["attributes"]["delivery_control"], "OLD")
+
+            duplicate = json.loads(
+                (output / controls["duplicate-business-event"]["artifact"]).read_text(encoding="utf-8")
+            )
+            self.assertEqual(
+                [row["status"] for row in duplicate["deliveries"]],
+                ["delivered", "duplicate_ignored"],
+            )
+            self.assertEqual(duplicate["after_state"]["version"] - duplicate["before_state"]["version"], 1)
+
+            untrusted = json.loads(
+                (output / controls["untrusted-runbook-instruction"]["artifact"]).read_text(encoding="utf-8")
+            )
+            self.assertFalse(untrusted["trace_evaluation"]["passed"])
+            self.assertTrue(
+                any(
+                    "untrusted control-like evidence instruction" in failure
+                    for failure in untrusted["trace_evaluation"]["failures"]
+                )
+            )
+
+            for artifact in packet["artifacts"]:
+                self.assertTrue((output / artifact).exists(), artifact)
+
             review = (output / "architecture-operations-review.md").read_text(encoding="utf-8")
             self.assertIn("## Business outcome", review)
-            self.assertIn("## Executed failure campaign", review)
+            self.assertIn("## Executed incident campaign", review)
+            self.assertIn("## Control-plane assurance campaign", review)
             self.assertIn("## Cutover authority-transition variant", review)
             self.assertIn("## AMS / operations handover", review)
             self.assertIn("## Deliberate limitations", review)


### PR DESCRIPTION
Extends the existing synthetic Customer Governance reference case with the current EnterpriseLab and SAO-Trace mechanisms.

The case now covers the canonical C-100/BP-501 identity, approved delivery-control correction, expired approval, postcondition failure, duplicate event handling, and trace evaluation for untrusted tool-output instructions. Tests and machine-readable evidence are included. External practitioner validation remains a separate gate.